### PR TITLE
Fix embedded struct marshalling

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -121,7 +121,8 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		field := t.Field(i)
 		val := v.Field(i)
 
-		jsonTag, jsonOpts := parseTag(field.Tag.Get("json"))
+		jsonTagVal, jsonTagExists := field.Tag.Lookup("json")
+		jsonTag, jsonOpts := parseTag(jsonTagVal)
 
 		// If no json tag is provided, use the field Name
 		if jsonTag == "" {
@@ -194,7 +195,7 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		// when a composition field we want to bring the child
 		// nodes to the top
 		nestedVal, ok := v.(KVStore)
-		if isEmbeddedField && ok {
+		if !jsonTagExists && isEmbeddedField && ok {
 			nestedVal.Each(func(k string, v interface{}) {
 				dest.Set(k, v)
 			})


### PR DESCRIPTION
Fixes struct marshalling for embedded structs when a `json` tag is specified.

Currently the following case works, and produces the same result as `json.Marshal`
```
type EmbeddedParent struct {
	*EmbeddedChild
}
```

However this case does not work as expected
```
type EmbeddedParent struct {
	*EmbeddedChild `json:"embedded"`
}
```

In the second case the outputted json is flattened, instead of nested as expected.